### PR TITLE
Add workflow to trigger kevinmgrimes.com rebuild

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,17 @@
+name: Notify kevinmgrimes.com
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger kevinmgrimes.com rebuild
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DISPATCH_TOKEN }}" \
+            https://api.github.com/repos/kgrimes2/kevinmgrimes.com/dispatches \
+            -d '{"event_type": "kdm-settlement-manager-updated"}'


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that sends a `repository_dispatch` event to `kgrimes2/kevinmgrimes.com` whenever `main` is pushed
- This triggers an automatic rebuild/deploy of the parent site when kdm-settlement-manager is updated

## Test plan
- [ ] Merge this PR, then push another change to main and verify the kevinmgrimes.com CI workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)