### PR TITLE
docs: update CHANGELOG and APP_VERSION for v1.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-02-11
+
+### Fixed
+- **NumericInput overlay click-through bug** - Clicking anywhere while +1/-1 buttons are visible now only closes the buttons without triggering the clicked element
+  - Added `preventDefault()` and `stopPropagation()` to overlay click handlers
+  - Overlay now completely blocks all page interactions while buttons are visible
+  - Prevents accidental checkbox toggles and input focus when closing buttons
+- **Attribute negative values** - Movement, evasion, accuracy, strength, luck, and speed inputs can now accept negative values
+  - Removed `min={0}` constraint from attribute NumericInput components
+  - Applies to both primary attribute values and gear bonus inputs
+
 ## [1.3.1] - 2026-02-10
 
 ### Fixed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import type { GlossaryTerm, WikiCategoryInfo } from './types/glossary'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import LoginModal from './components/LoginModal'
 
-const APP_VERSION = '1.3.1'
+const APP_VERSION = '1.3.2'
 
 type QuadrantId = 1 | 2 | 3 | 4 | null
 


### PR DESCRIPTION
Updates the CHANGELOG.md and APP_VERSION constant that were missed in the initial v1.3.2 release PR (#25).

## Changes
- Added v1.3.2 section to CHANGELOG.md documenting the NumericInput overlay fix and negative attribute values support
- Updated APP_VERSION constant in src/App.tsx from '1.3.1' to '1.3.2'

## Related
- Follows up on #25